### PR TITLE
Fully initialize struct uio

### DIFF
--- a/sys/external/bsd/drm2/dist/drm/i915/i915_gem.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_gem.c
@@ -5845,8 +5845,10 @@ i915_gem_object_create_from_data(struct drm_device *dev,
 	struct uio uio = {
 	    .uio_iov = &iov,
 	    .uio_iovcnt = 1,
+	    .uio_offset = 0,
 	    .uio_resid = size,
 	    .uio_rw = UIO_WRITE,
+	    .uio_vmspace = curproc->p_vmspace
 	};
 #else
 	struct sg_table *sg;


### PR DESCRIPTION
XXX more thoughts
dh says; you should be able to use uiomove to move from a kernel pointer; you just need to set uio_seg properly

but we get a null dereference on uio_vmspace being uninitialized, because uiomove VMSPACE_IS_KERNEL_P dereferences it.