### PR TITLE
PCI drivers need set_busid = drm_pci_set_busid.

### DIFF
--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_mman.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_mman.h
@@ -20,7 +20,10 @@ struct i915_mmap_offset;
 struct mutex;
 
 int i915_gem_mmap_gtt_version(void);
-#ifdef __linux__
+#ifdef __NetBSD__
+int i915_gem_fault(struct uvm_faultinfo *, vaddr_t, struct vm_page **,
+    int, int, vm_prot_t, int);
+#else
 int i915_gem_mmap(struct file *filp, struct vm_area_struct *vma);
 #endif
 

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_mman.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_mman.h
@@ -20,7 +20,9 @@ struct i915_mmap_offset;
 struct mutex;
 
 int i915_gem_mmap_gtt_version(void);
+#ifdef __linux__
 int i915_gem_mmap(struct file *filp, struct vm_area_struct *vma);
+#endif
 
 int i915_gem_dumb_mmap_offset(struct drm_file *file_priv,
 			      struct drm_device *dev,

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -450,34 +450,6 @@ static void i915_workqueues_cleanup(struct drm_i915_private *dev_priv)
 	destroy_workqueue(dev_priv->wq);
 }
 
-static const struct intel_device_info intel_kabylake_info = {
-	.is_kabylake = 1,
-	.gen = 9,
-	.num_pipes = 3,
-	.need_gfx_hws = 1, .has_hotplug = 1,
-	.ring_mask = RENDER_RING | BSD_RING | BLT_RING | VEBOX_RING,
-	.has_llc = 1,
-	.has_ddi = 1,
-	.has_fpga_dbg = 1,
-	.has_fbc = 1,
-	GEN_DEFAULT_PIPEOFFSETS,
-	IVB_CURSOR_OFFSETS,
-};
-
-static const struct intel_device_info intel_kabylake_gt3_info = {
-	.is_kabylake = 1,
-	.gen = 9,
-	.num_pipes = 3,
-	.need_gfx_hws = 1, .has_hotplug = 1,
-	.ring_mask = RENDER_RING | BSD_RING | BLT_RING | VEBOX_RING | BSD2_RING,
-	.has_llc = 1,
-	.has_ddi = 1,
-	.has_fpga_dbg = 1,
-	.has_fbc = 1,
-	GEN_DEFAULT_PIPEOFFSETS,
-	IVB_CURSOR_OFFSETS,
-};
-
 /*
  * We don't keep the workarounds for pre-production hardware, so we expect our
  * driver to fail on these machines in one way or another. A little warning on

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -2845,6 +2845,16 @@ static const struct drm_ioctl_desc i915_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(I915_GEM_VM_DESTROY, i915_gem_vm_destroy_ioctl, DRM_RENDER_ALLOW),
 };
 
+#ifdef __NetBSD__
+
+static const struct uvm_pagerops i915_gem_uvm_ops = {
+	.pgo_reference = drm_gem_pager_reference,
+	.pgo_detach = drm_gem_pager_detach,
+	.pgo_fault = i915_gem_fault,
+};
+
+#endif
+
 static struct drm_driver driver = {
 	/* Don't use MTRRs here; the Xserver or userspace app should
 	 * deal with them for Intel hardware.
@@ -2894,13 +2904,3 @@ static struct drm_driver driver = {
 	.minor = DRIVER_MINOR,
 	.patchlevel = DRIVER_PATCHLEVEL,
 };
-
-#ifdef __NetBSD__
-
-static const struct uvm_pagerops i915_gem_uvm_ops = {
-	.pgo_reference = drm_gem_pager_reference,
-	.pgo_detach = drm_gem_pager_detach,
-	.pgo_fault = i915_gem_fault,
-};
-
-#endif

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -1690,7 +1690,9 @@ static int i915_driver_open(struct drm_device *dev, struct drm_file *file)
 static void i915_driver_lastclose(struct drm_device *dev)
 {
 	intel_fbdev_restore_mode(dev);
+#ifndef __NetBSD__		/* XXX vga */
 	vga_switcheroo_process_delayed_switch();
+#endif
 }
 
 static void i915_driver_postclose(struct drm_device *dev, struct drm_file *file)

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -97,6 +97,8 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #endif
 #endif
 
+#include <linux/nbsd-namespace.h>
+
 static struct drm_driver driver;
 
 #ifdef __NetBSD__

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -1814,7 +1814,7 @@ get_suspend_mode(struct drm_i915_private *dev_priv, bool hibernate)
 	return I915_DRM_SUSPEND_MEM;
 }
 
-static int i915_drm_suspend_late(struct drm_device *dev, bool hibernation)
+int i915_drm_suspend_late(struct drm_device *dev, bool hibernation)
 {
 	struct drm_i915_private *dev_priv = to_i915(dev);
 	struct pci_dev *pdev = dev_priv->drm.pdev;

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -2043,8 +2043,6 @@ int i915_drm_resume_early(struct drm_device *dev)
 
 	enable_rpm_wakeref_asserts(&dev_priv->runtime_pm);
 
-	i915_rc6_ctx_wa_resume(dev_priv);
-
 	return ret;
 }
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -1241,11 +1241,13 @@ static int i915_driver_hw_probe(struct drm_i915_private *dev_priv)
 
 	pci_set_master(pdev);
 
+#ifdef __linux__
 	/*
 	 * We don't have a max segment size, so set it to the max so sg's
 	 * debugging layer doesn't complain
 	 */
 	dma_set_max_seg_size(&pdev->dev, UINT_MAX);
+#endif
 
 #ifndef __NetBSD__		/* Handled in intel_ggtt.c.  */
 	/* overlay on gen2 is broken and can't address above 1G */

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -1971,7 +1971,9 @@ int i915_drm_resume(struct drm_device *dev)
 int i915_drm_resume_early(struct drm_device *dev)
 {
 	struct drm_i915_private *dev_priv = to_i915(dev);
+#ifndef __NetBSD__
 	struct pci_dev *pdev = dev_priv->drm.pdev;
+#endif
 	int ret;
 
 	/*

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -892,12 +892,6 @@ skl_dram_get_channels_info(struct drm_i915_private *dev_priv)
 	return 0;
 }
 
-#ifdef __NetBSD__
-/* XXX Kludge to expose this to NetBSD driver attachment goop.  */
-const struct pci_device_id *const i915_device_ids = pciidlist;
-const size_t i915_n_device_ids = __arraycount(pciidlist);
-#endif
-
 static enum intel_dram_type
 skl_get_dram_type(struct drm_i915_private *dev_priv)
 {

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -48,6 +48,7 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_ioctl.h>
 #include <drm/drm_irq.h>
+#include <drm/drm_pci.h>
 #include <drm/drm_probe_helper.h>
 #include <drm/i915_drm.h>
 
@@ -1991,10 +1992,7 @@ int i915_drm_resume_early(struct drm_device *dev)
 	 * the device powered we can also remove the following set power state
 	 * call.
 	 */
-#ifdef __NetBSD__		/* pmf handles this for us.  */
-	if (0)
-		goto out;
-#else
+#ifndef __NetBSD__		/* pmf handles this for us.  */
 	ret = pci_set_power_state(pdev, PCI_D0);
 	if (ret) {
 		DRM_ERROR("failed to set PCI D0 power state (%d)\n", ret);
@@ -2141,7 +2139,6 @@ static int i915_pm_resume(struct device *kdev)
 
 	return i915_drm_resume(&i915->drm);
 }
-#endif
 
 /* freeze: before creating the hibernation_image */
 static int i915_pm_freeze(struct device *kdev)
@@ -2425,6 +2422,7 @@ static int vlv_wait_for_pw_status(struct drm_i915_private *i915,
 
 	return ret;
 }
+#endif
 
 int vlv_force_gfx_clock(struct drm_i915_private *dev_priv, bool force_on)
 {
@@ -2452,6 +2450,7 @@ int vlv_force_gfx_clock(struct drm_i915_private *dev_priv, bool force_on)
 	return err;
 }
 
+#ifndef __NetBSD__		/* XXX vlv suspend/resume */
 static int vlv_allow_gt_wake(struct drm_i915_private *dev_priv, bool allow)
 {
 	u32 mask;
@@ -2576,6 +2575,7 @@ static int vlv_resume_prepare(struct drm_i915_private *dev_priv,
 
 	return ret;
 }
+#endif
 
 #ifndef __NetBSD__		/* XXX runtime pm */
 static int intel_runtime_suspend(struct device *kdev)

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.c
@@ -1483,7 +1483,7 @@ i915_driver_create(struct pci_dev *pdev, const struct pci_device_id *ent)
 	if (!i915)
 		return ERR_PTR(-ENOMEM);
 
-	err = drm_dev_init(&i915->drm, &driver, &pdev->dev);
+	err = drm_dev_init(&i915->drm, &driver, device_parent(pdev->pd_dev));
 	if (err) {
 		kfree(i915);
 		return ERR_PTR(err);

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
@@ -1817,6 +1817,11 @@ extern const struct dev_pm_ops i915_pm_ops;
 int i915_driver_probe(struct pci_dev *pdev, const struct pci_device_id *ent);
 void i915_driver_remove(struct drm_i915_private *i915);
 
+int i915_drm_resume(struct drm_device *);
+int i915_drm_resume_early(struct drm_device *);
+int i915_drm_suspend(struct drm_device *);
+int i915_drm_suspend_late(struct drm_device *, bool);
+
 int i915_resume_switcheroo(struct drm_i915_private *i915);
 int i915_suspend_switcheroo(struct drm_i915_private *i915, pm_message_t state);
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
@@ -918,7 +918,7 @@ struct i915_selftest_stash {
 struct drm_i915_private {
 	struct drm_device drm;
 
-	const struct intel_device_info __info; /* Use INTEL_INFO() to access. */
+	struct intel_device_info __info; /* Use INTEL_INFO() to access. */
 	struct intel_runtime_info __runtime; /* Use RUNTIME_INFO() to access. */
 	struct intel_driver_caps caps;
 
@@ -2004,10 +2004,10 @@ int intel_engine_cmd_parser(struct intel_engine_cs *engine,
 #define I915_CMD_PARSER_TRAMPOLINE_SIZE 8
 
 /* intel_device_info.c */
-static inline const struct intel_device_info *
+static inline struct intel_device_info *
 mkwrite_device_info(struct drm_i915_private *dev_priv)
 {
-	return (const struct intel_device_info *)INTEL_INFO(dev_priv);
+	return (struct intel_device_info *)INTEL_INFO(dev_priv);
 }
 
 int i915_reg_read_ioctl(struct drm_device *dev, void *data,

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
@@ -1381,7 +1381,7 @@ static inline struct drm_i915_private *pdev_to_i915(struct pci_dev *pdev)
 #define for_each_uabi_engine(engine__, i915__) \
 	for ((engine__) = rb_to_uabi_engine(rb_first(&(i915__)->uabi_engines));\
 	     (engine__); \
-	     (engine__) = rb_to_uabi_engine(rb_next(&(engine__)->uabi_node)))
+	     (engine__) = rb_to_uabi_engine(rb_next2(&(i915__)->uabi_engines, &(engine__)->uabi_node)))
 
 #define I915_GTT_OFFSET_NONE ((u32)-1)
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_request.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_request.h
@@ -201,7 +201,11 @@ struct i915_request {
 	 */
 	struct i915_sw_fence submit;
 	union {
+#ifdef __linux__
 		wait_queue_entry_t submitq;
+#else
+		kcondvar_t submitq;
+#endif
 		struct i915_sw_dma_fence_cb dmaq;
 		struct i915_request_duration_cb {
 			struct dma_fence_cb cb;

--- a/sys/external/bsd/drm2/i915drm/files.i915drmkms
+++ b/sys/external/bsd/drm2/i915drm/files.i915drmkms
@@ -18,6 +18,7 @@ makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-I$S/external/bsd/drm2/dist/drm/i
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_FBDEV_EMULATION=1"
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_DEBUG=1" # XXX
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_DEBUG_GEM=1" # XXX
+makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_DEBUG_RUNTIME_PM=1" # XXX
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_PREEMPT_TIMEOUT=640"
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_TIMESLICE_DURATION=1"
 makeoptions	i915drmkms	"CPPFLAGS.i915drmkms"+="-DCONFIG_DRM_I915_ALPHA_SUPPORT=0"

--- a/sys/external/bsd/drm2/include/linux/rbtree.h
+++ b/sys/external/bsd/drm2/include/linux/rbtree.h
@@ -69,6 +69,11 @@ rb_first(struct rb_root *root)
 }
 
 static inline struct rb_node *
+rb_next2(struct rb_root *root, struct rb_node *rb) {
+	return RB_TREE_NEXT(&root->rbr_tree, rb);
+}
+
+static inline struct rb_node *
 rb_last(struct rb_root *root)
 {
 	char *vnode = RB_TREE_MAX(&root->rbr_tree);


### PR DESCRIPTION
libdrm expects GetBusid to be of the form pci0009:09:00.0 and
to match it against a PCI bus ID. Returning "radeon0" makes it
consider modesetting to be broken.